### PR TITLE
feat: remove worktree after successful in-review status write

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -180,6 +180,9 @@ func runOneTask(ctx context.Context, d RunFeatureDeps, snap *Snapshot, task Task
 			prNum = res.PR.Number
 		}
 		d.Progress.TaskInReview(task.Number, prNum)
+		if err := RemoveWorktree(ctx, d.Runner, d.RepoRoot, wtPath); err != nil {
+			d.Progress.Note("warn: could not remove worktree for #%d: %v", task.Number, err)
+		}
 
 	case OutcomeNeedsAttention:
 		if err := WriteStatus(ctx, d.Runner, d.Config, task.ItemID, "Needs Attention", time.Second); err != nil {

--- a/runner_test.go
+++ b/runner_test.go
@@ -55,6 +55,7 @@ func TestRunFeature_HappyPath_OneEligibleTaskOpensPR(t *testing.T) {
 	wtPath := WorktreePath(filepath.Join(repoRoot, "wt-root"), "proj", 7, 42)
 	r.Stub([]string{"git", "-C", repoRoot, "worktree", "prune"}, nil, nil)
 	r.Stub([]string{"git", "-C", repoRoot, "worktree", "add", wtPath, "-b", "klanky/feat-7/task-42", "main"}, nil, nil)
+	r.Stub([]string{"git", "-C", repoRoot, "worktree", "remove", wtPath, "--force"}, nil, nil)
 
 	// Status writes (in-progress, then in-review). Both succeed first try.
 	r.Stub([]string{"gh", "project", "item-edit",

--- a/worktree.go
+++ b/worktree.go
@@ -42,3 +42,13 @@ func EnsureCleanWorktree(ctx context.Context, r Runner, repoRoot, wtPath, branch
 	}
 	return nil
 }
+
+// RemoveWorktree tears down the per-task worktree at wtPath. Uses --force so
+// untracked agent scratch files (TDD experiments, build artifacts) don't block
+// cleanup of an otherwise successful task.
+func RemoveWorktree(ctx context.Context, r Runner, repoRoot, wtPath string) error {
+	if _, err := r.Run(ctx, "git", "-C", repoRoot, "worktree", "remove", wtPath, "--force"); err != nil {
+		return fmt.Errorf("git worktree remove %s: %w", wtPath, err)
+	}
+	return nil
+}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -43,6 +43,15 @@ func TestEnsureCleanWorktree_WipesExistingPath(t *testing.T) {
 	}
 }
 
+func TestRemoveWorktree_CallsGitWorktreeRemove(t *testing.T) {
+	r := NewFakeRunner()
+	r.Stub([]string{"git", "-C", "/repo", "worktree", "remove", "/some/path", "--force"}, nil, nil)
+
+	if err := RemoveWorktree(context.Background(), r, "/repo", "/some/path"); err != nil {
+		t.Fatalf("RemoveWorktree: %v", err)
+	}
+}
+
 func TestWorktreePath_StableLayout(t *testing.T) {
 	got := WorktreePath("/home/u/.klanky/worktrees", "myrepo", 7, 42)
 	want := "/home/u/.klanky/worktrees/myrepo/feat-7/task-42"


### PR DESCRIPTION
## Summary

After a task's agent successfully opens its PR and the runner flips Status to **In Review**, klanky now tears down the per-task worktree at `~/.klanky/worktrees/<repo>/feat-F/task-T/`. Previously these worktrees lingered, blocking `gh pr checkout` and manual branch checkouts of the agent's branch.

Failure (`Needs Attention`) worktrees are still preserved for human inspection — only the success path cleans up.

## Changes

- `worktree.go`: new `RemoveWorktree(ctx, runner, repoRoot, wtPath)` — shells `git -C <repo> worktree remove <path> --force`. `--force` covers untracked agent scratch (TDD experiments, build artifacts) so cleanup doesn't fail on bystanders.
- `runner.go`: in `runOneTask`, after `WriteStatus(... "In Review" ...)` and `Progress.TaskInReview(...)`, call `RemoveWorktree`. Errors are best-effort logged via `Progress.Note`, matching the existing pattern.
- Tests: unit test for `RemoveWorktree` and stub addition to the happy-path `RunFeature` test.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean

Closes #7