### PR TITLE
chore: drop release-as bootstrap pin now that 0.0.1 has shipped

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,8 +7,6 @@
   "draft": false,
   "prerelease": false,
   "packages": {
-    ".": {
-      "release-as": "0.0.1"
-    }
+    ".": {}
   }
 }


### PR DESCRIPTION
Now that v0.0.1 is out and the release-please manifest reads `0.0.1`, the `release-as` pin in the config is no longer needed. Removing it lets conventional commits drive subsequent versions organically.

After this lands:
- `feat:` PRs will produce the next minor release (v0.1.0).
- `fix:` PRs will produce the next patch release (v0.0.2).
- `feat!:` PRs will produce the next minor release while pre-1.0 (`bump-minor-pre-major: true`).