### PR TITLE
ci: use PAT for release-please so tags auto-trigger goreleaser

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Adds `token: ${{ secrets.RELEASE_PLEASE_TOKEN }}` to the `googleapis/release-please-action@v4` step so release-please pushes release tags as the PAT actor instead of `GITHUB_TOKEN`.

## Why

GitHub Actions intentionally suppresses workflow triggers from `GITHUB_TOKEN`-actor events. With the default token, release-please pushes the `vX.Y.Z` tag but `release.yml` (goreleaser) — which fires on `push: tags: v*` — never runs, so the GitHub Release ends up with no binaries. v0.0.1 was unblocked by running goreleaser locally; this change makes future releases auto-publish.

A fine-grained PAT (`Contents: read/write`, `Pull requests: read/write`, scoped to `joshuapeters/klanky`) has been added as the repo secret `RELEASE_PLEASE_TOKEN`.

## Validation

`actionlint` clean on the modified workflow. The change cannot be fully validated until a future release-worthy commit exercises the path. Acceptance test:

- A subsequent `feat:`/`fix:` PR lands on `main`.
- release-please opens a `chore(main): release X.Y.Z` PR (already working today).
- Merging that PR creates a `vX.Y.Z` tag — and `gh run list --workflow release.yml` should show a new run starting within seconds.
- `gh release view vX.Y.Z` shows 4 `.tar.gz` files + `checksums.txt`.

Closes #15.