### PR TITLE
fix: thread version metadata as params and drop fprintf err checks

### DIFF
--- a/cmd_version.go
+++ b/cmd_version.go
@@ -6,21 +6,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newVersionCmd() *cobra.Command {
+func newVersionCmd(v, c, d string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the build version, commit, and date",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
-			if _, err := fmt.Fprintf(out, "klanky %s\n", version); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintf(out, "commit: %s\n", commit); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintf(out, "built:  %s\n", date); err != nil {
-				return err
-			}
+			fmt.Fprintf(out, "klanky %s\n", v)
+			fmt.Fprintf(out, "commit: %s\n", c)
+			fmt.Fprintf(out, "built:  %s\n", d)
 			return nil
 		},
 	}

--- a/cmd_version_test.go
+++ b/cmd_version_test.go
@@ -7,19 +7,13 @@ import (
 )
 
 func TestVersionCommand_PrintsAllThreeFields(t *testing.T) {
-	// Override the package-level build vars so the test is deterministic
-	// regardless of how the binary was built. Restore them after.
-	origV, origC, origD := version, commit, date
-	version = "v9.9.9"
-	commit = "deadbeef"
-	date = "2026-05-01T00:00:00Z"
-	defer func() { version, commit, date = origV, origC, origD }()
+	t.Parallel()
 
 	out := &bytes.Buffer{}
-	cmd := newRootCmd()
+	cmd := newVersionCmd("v9.9.9", "deadbeef", "2026-05-01T00:00:00Z")
 	cmd.SetOut(out)
 	cmd.SetErr(out)
-	cmd.SetArgs([]string{"version"})
+	cmd.SetArgs([]string{})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("expected `version` to succeed, got: %v", err)
@@ -34,6 +28,8 @@ func TestVersionCommand_PrintsAllThreeFields(t *testing.T) {
 }
 
 func TestRootCommand_Help_ListsVersionSubcommand(t *testing.T) {
+	t.Parallel()
+
 	out := &bytes.Buffer{}
 	cmd := newRootCmd()
 	cmd.SetOut(out)

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newFeatureCmd(cfgPath))
 	root.AddCommand(newTaskCmd(cfgPath))
 	root.AddCommand(newRunCmd(cfgPath))
-	root.AddCommand(newVersionCmd())
+	root.AddCommand(newVersionCmd(version, commit, date))
 
 	return root
 }


### PR DESCRIPTION
## Summary

Combines #11 and #12 since both touch the same `RunE` in `cmd_version.go`.

- **#11** — `newVersionCmd` now takes `version`/`commit`/`date` as parameters instead of closing over the package-level vars. The var-swap pattern in `cmd_version_test.go` is gone, and both tests in that file now use `t.Parallel()` to lock in the property.
- **#12** — Drops the three `if _, err := fmt.Fprintf(...); err != nil { return err }` blocks in the same `RunE`, aligning with how every other stdout write in the codebase already behaves.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`

## Release pipeline note

This is a `fix:` commit, so once merged release-please should open a `chore(main): release 0.0.2` PR. Merging that PR is the actual end-to-end test of the PAT wiring from #15 — tag push should auto-trigger goreleaser and produce a GitHub Release with binaries.

Closes #11.
Closes #12.