### PR TITLE
feat: bundle agent skills (klanky-init, klanky-project, klanky-plan)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,19 @@ no inter-machine meaning and would only clutter the repo.
 When in doubt: if a piece of state would be identical across every
 checkout of this repo, it belongs in the repo. If it'd legitimately
 differ per-machine, it belongs under `~/.klanky/`.
+
+## `skills/` is the published consumer bundle
+
+The `skills/` directory at the repo root contains agent skills that ship
+to *consumer* repos via `npx skills add joshuapeters/klanky`. Their
+audience is agents using klanky against arbitrary repos, not contributors
+working on klanky itself.
+
+When editing files in `skills/`, treat the audience accordingly:
+
+- Assume the agent has zero prior context for klanky beyond the README
+  and the skill it's reading.
+- Don't reference klanky's source code, internal packages, or
+  contributor conventions — they aren't visible to a consumer-side agent.
+- Keep each skill self-contained. Skills are not loaded as a chain;
+  any prerequisite knowledge has to live in the skill that needs it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,15 +35,17 @@ differ per-machine, it belongs under `~/.klanky/`.
 ## `skills/` is the published consumer bundle
 
 The `skills/` directory at the repo root contains agent skills that ship
-to *consumer* repos via `npx skills add joshuapeters/klanky`. Their
-audience is agents using klanky against arbitrary repos, not contributors
-working on klanky itself.
+to any repo (including this one) via `npx skills add joshuapeters/klanky`.
+The audience is agents *using* klanky as a tool — which includes agents
+hacking on klanky's own source, since klanky is dogfooded here.
 
-When editing files in `skills/`, treat the audience accordingly:
+When editing files in `skills/`, the content is *user-facing*, not
+contributor-facing:
 
-- Assume the agent has zero prior context for klanky beyond the README
-  and the skill it's reading.
+- Assume the reader has zero prior context for klanky beyond the README
+  and the skill they're reading.
 - Don't reference klanky's source code, internal packages, or
-  contributor conventions — they aren't visible to a consumer-side agent.
+  contributor conventions — those belong in this file (`AGENTS.md`) or
+  inline in the source, not in skills that ship to other repos too.
 - Keep each skill self-contained. Skills are not loaded as a chain;
   any prerequisite knowledge has to live in the skill that needs it.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ Run all commands from the root of the repo you want Klanky to manage. Per-repo s
 
 For machine-readable output, pass `--output json` (or set `default_output: json` in `.klankyrc.json`) to any stdout-emitting command.
 
+## Skills
+
+Klanky ships agent skills that teach an AI coding agent how to use it.
+They live under [`skills/`](skills/) in this repo and install in any
+consumer repo via the open agent-skills CLI:
+
+```
+npx skills add joshuapeters/klanky
+```
+
+Three skills are bundled:
+
+- `klanky-init` — bootstrap klanky in a fresh repo (one-time).
+- `klanky-project` — create, link, and inspect klanky projects.
+- `klanky-plan` — plan a workstream as a sized, dep'd klanky issue DAG.
+
+These are for agents working *with* klanky in consumer repos. See
+[`skills/README.md`](skills/README.md) for details.
+
 ## Contributing
 
 PRs welcome. Conventions:

--- a/skills/README.md
+++ b/skills/README.md
@@ -19,6 +19,7 @@ npx skills add joshuapeters/klanky
 
 ## Audience
 
-These skills are for agents working *with* klanky in consumer repos — not
-for agents hacking on klanky's own source. Klanky must already be installed
-and on `PATH`; see the top-level README for install instructions.
+These skills teach an agent how to *use* klanky in any repo where it's
+installed — including klanky's own source repo, which is dogfooded with
+klanky. Klanky must already be on `PATH`; see the top-level README for
+install instructions.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,24 @@
+# klanky skills
+
+Agent skills bundled with klanky, installable in any consumer repo via:
+
+```
+npx skills add joshuapeters/klanky
+```
+
+## Skills
+
+- **`klanky-init`** — Bootstrap klanky in a fresh repo (one-time): verify
+  prerequisites, run `klanky init`, point at next steps.
+- **`klanky-project`** — Create, link, and inspect klanky projects. Teaches
+  the project schema (Status field + `klanky:tracked` label + GH-native
+  `blocked by` deps) and the new-vs-link decision.
+- **`klanky-plan`** — Plan a workstream as a klanky issue DAG. Sizing
+  rubric, body checklist, decomposition decision tree, and a worked Auth
+  example.
+
+## Audience
+
+These skills are for agents working *with* klanky in consumer repos — not
+for agents hacking on klanky's own source. Klanky must already be installed
+and on `PATH`; see the top-level README for install instructions.

--- a/skills/klanky-init/SKILL.md
+++ b/skills/klanky-init/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: klanky-init
+description: Bootstrap klanky in a fresh repo. Verify prerequisites (gh CLI with project scope, claude CLI on PATH), run `klanky init --repo owner/name`, and point the user at next steps. Use when a user asks to set up klanky in this repo, when starting a klanky workflow, or when `.klankyrc.json` does not exist.
+---
+
+# klanky-init
+
+Bootstrap klanky in this repo. One-time per repo. After this, register
+projects with the `klanky-project` skill, then populate them with
+`klanky-plan`.
+
+## Prerequisites
+
+Klanky shells out to `gh` and `claude`. Verify both before running init.
+
+### 1. `gh` CLI with `project` scope
+
+Klanky reads and writes GitHub Projects v2 boards, which requires the
+`project` OAuth scope. The default `gh auth login` does NOT include it.
+
+Check current scopes:
+
+```
+gh auth status
+```
+
+If the output does not include `project` in the list of token scopes,
+refresh:
+
+```
+gh auth refresh -s project
+```
+
+Then re-run `gh auth status` to confirm `project` is now listed.
+
+If `gh` itself is not installed, see https://cli.github.com.
+
+### 2. `claude` CLI on `PATH`
+
+Klanky spawns `claude -p` per issue.
+
+```
+command -v claude
+```
+
+If this prints a path, you're set. If it prints nothing, install Claude
+Code from https://docs.claude.com/en/docs/claude-code.
+
+### 3. `klanky` itself
+
+```
+command -v klanky
+```
+
+If missing, see klanky's README for install instructions
+(https://github.com/joshuapeters/klanky).
+
+## Init
+
+Once all three CLIs are present, run from the repo root:
+
+```
+klanky init --repo <owner>/<name>
+```
+
+Replace `<owner>/<name>` with the GitHub `owner/repo` slug. This writes
+`.klankyrc.json` at the repo root with no projects linked yet.
+
+## What happened
+
+Klanky now knows two things about this repo:
+
+- **Repo binding** — `.klankyrc.json` exists with the `owner/repo` you
+  passed. This file is committed and travels with the repo, so any machine
+  that runs `git clone && klanky run` works without re-bootstrapping.
+- **Per-machine state location** — Logs, locks, and worktrees will live
+  under `~/.klanky/<class>/<owner>/<repo>/<slug>/...` once you start
+  running. Nothing is created there yet.
+
+The `.klankyrc.json` file is intentionally minimal at this point — no
+projects are linked. That's the next step.
+
+## Next step
+
+Register a project. Two paths:
+
+- A board does not yet exist for the workstream you want to manage (most
+  common): use the `klanky-project` skill to run `klanky project new`.
+- A board already exists on GitHub for this workstream: use the
+  `klanky-project` skill to run `klanky project link <url>`.
+
+Either way, hand off to the `klanky-project` skill from here.
+
+## Inline example
+
+Fresh repo, no klanky setup yet:
+
+```
+$ gh auth status
+github.com
+  ✓ Logged in to github.com account jp
+  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
+  # ^ no `project` scope
+
+$ gh auth refresh -s project
+# browser flow; approve project scope
+✓ Authentication complete.
+
+$ command -v claude
+/Users/jp/.local/bin/claude
+
+$ command -v klanky
+/usr/local/bin/klanky
+
+$ klanky init --repo myorg/myapp
+wrote .klankyrc.json (repo: myorg/myapp, projects: 0)
+
+$ cat .klankyrc.json
+{
+  "repo": "myorg/myapp",
+  "projects": []
+}
+```
+
+Now hand off to `klanky-project`.

--- a/skills/klanky-plan/SKILL.md
+++ b/skills/klanky-plan/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: klanky-plan
+description: Plan a workstream as a klanky issue DAG. Decompose the work into right-sized, vertically-sliced issues with explicit `--depends-on` ordering, and write each issue body to be a sufficient brief for the per-issue runner agent. Use when a user has a workstream (a feature, a migration, an initiative) they want to break into shippable issues for klanky's runner, or when they want to add issues to an existing klanky project.
+---
+
+# klanky-plan
+
+Turn a workstream into a runnable klanky issue DAG. The output is a set
+of GitHub issues, each labeled `klanky:tracked`, attached to one project,
+with explicit `blocked by` relations forming a DAG that the runner can
+pick from.
+
+This skill assumes a klanky project already exists. If one doesn't, run
+the `klanky-project` skill first.
+
+## What the runner sees
+
+Crucial framing: the per-issue runner agent only sees the issue *body*.
+It gets a sealed envelope with that body and instructions to ship a PR.
+It does NOT see the workstream description, the other issues, or this
+planning conversation.
+
+Everything the runner needs to do its job has to live in the body of the
+issue you write. That's why body quality is load-bearing — see
+[Body checklist](#body-checklist) below.
+
+## Sizing rubric
+
+A good klanky tracked issue is:
+
+1. **Small** — narrow in scope.
+2. **A vertical slice** — touches whatever layers it needs (DB, API, UI,
+   …) to deliver something independently shippable. Not "build the
+   schema", then "build the API", then "build the UI" as separate issues.
+3. **Human-reviewable** — the resulting PR can be read end-to-end by a
+   person in one sitting.
+4. **Fits the agent's smart zone** — the issue's work plus the
+   surrounding repo context an agent will load to do it stays inside the
+   first ~100–200k tokens of context window, where the model is sharpest.
+
+These constraints are **soft** — there's no lint rule. But if a planned
+issue clearly violates one, that's the trigger to decompose it further.
+
+## Body checklist
+
+Every tracked issue body must contain enough for the runner agent to do
+the work without upstream context. **Required:**
+
+- **Outcome.** One sentence: what's true after this issue is merged.
+- **Acceptance criteria.** Bullet list, testable.
+- **Scope boundaries.** What's in. What's NOT in (deferred to which
+  other issues, or out of scope entirely).
+- **File / area pointers.** Where in the repo this work lives.
+- **Test expectations.** What tests must exist or pass for this to be
+  done.
+
+**Optional, when relevant:**
+
+- Pointers to related issues, design context, or prior PRs.
+- External references (RFCs, library docs, ADRs).
+- Sample inputs / expected outputs for tricky logic.
+
+This is a checklist, not a literal template — assemble a body that
+contains all required elements in whatever shape suits the issue.
+
+## Mechanics
+
+For each node in the DAG:
+
+1. Write the body to a file. Convention:
+   `.docs/issues/<slug>-<short-description>.md`. Keeps a paper trail and
+   avoids shell-escaping pain.
+2. Run:
+
+   ```
+   klanky issue add \
+     --project <slug> \
+     --title "<one-line title>" \
+     --body-file .docs/issues/<slug>-<short>.md
+   ```
+
+3. For each predecessor, add `--depends-on <issue-number>` (repeatable).
+   The flag takes the GitHub issue number that this new issue is blocked
+   by. You'll know predecessor numbers because they were added earlier in
+   this session and `klanky issue add` prints the new issue number.
+4. After all nodes are added, verify the DAG by browsing the project
+   board on GitHub or running `klanky project list` (then visiting the
+   URL).
+
+Always add foundation issues (no deps) first, then their dependents in
+topological order. Don't try to add an issue with `--depends-on N` before
+issue N exists.
+
+## Decomposition decision tree
+
+When a candidate issue feels too big, work through these in order:
+
+1. **Can I cut horizontally (DB → API → UI)?** → No. Vertical slices
+   only. Horizontal cuts can't ship in isolation and defer integration
+   risk to the end of the workstream.
+2. **Can I cut by feature surface (one auth provider at a time, one
+   resource type at a time)?** → Usually yes. Share a foundation issue
+   and `--depends-on` it from each surface.
+3. **Can I cut by user-visible flow (signup vs. login vs. password
+   change)?** → Usually yes. Each flow tends to be its own vertical
+   slice.
+4. **Can I cut by data scope (read path vs. write path)?** → Sometimes;
+   works best when the read path can ship and be useful to users before
+   writes exist.
+
+If none of these apply and the issue still violates the rubric, the
+workstream itself may need rethinking — flag it to the user before
+proceeding.
+
+## Anti-patterns
+
+- **Horizontal slicing** — "build the database", "build the API", "build
+  the UI" as separate issues. Nothing ships independently, and
+  integration is deferred.
+- **"Spike" or "research" issues** — the planner's job is to know what
+  to build. Spikes belong in interactive sessions, not the runner queue.
+- **Empty bodies** — the runner only sees the body. Empty body =
+  unrunnable. Confirm every issue has all required body elements before
+  adding.
+- **Missing deps** — the runner picks unblocked issues in parallel.
+  Missing deps mean two agents will trample each other and produce
+  conflict-ridden PRs.
+- **Mega-issues that "we'll just split later"** — split now. Once an
+  issue is in flight, it's hard to retract.
+
+## Worked example: Auth as a DAG
+
+**Workstream:** "Add user authentication to this app."
+
+A naive single-issue framing fails the rubric on every count: not
+vertically sliceable as a whole, blows past the smart zone, the resulting
+PR would not be human-reviewable. Decompose.
+
+| #  | Issue                                  | Deps  | Why it's a vertical slice                                              |
+|----|----------------------------------------|-------|------------------------------------------------------------------------|
+| 1  | Auth backend skeleton                  | —     | `User` table + password-hashing util + session model + tests. No UI.   |
+| 2  | User-pass signup + login UI            | 1     | Forms → backend → session cookie → redirect. End-to-end signup flow.   |
+| 3  | Account confirmation email flow        | 1     | Token gen + email send + confirm endpoint. Independent of #2's UI.     |
+| 4  | Logout + session expiry                | 2     | Endpoint + UI affordance. Builds on the active-session world from #2.  |
+| 5  | Username / password change             | 2     | Settings form + current-password re-verify + update endpoint.          |
+| 6  | OAuth (Google) sign-in                 | 1, 2  | Alternate IdP plugged into the same login surface from #2.             |
+| 7  | SSO / SAML                             | 6     | Extends OAuth scaffolding to enterprise providers.                     |
+
+Why this works:
+
+- Each issue is a **vertical slice**: it touches whatever layers it
+  needs to deliver something a user can exercise (or, for #1, a
+  foundation other issues can build on).
+- Deps prevent premature parallelism. #4 needs the active-session world
+  from #2; #6 needs both #1's user model and #2's login surface.
+- #2 and #3 are dep'd on #1 but **not on each other** — the runner can
+  pick them up in parallel once #1 lands.
+- Every issue is reviewable as one PR.
+- Every issue's surface area fits comfortably inside the smart zone.
+
+### A sample body for issue #1 (Auth backend skeleton)
+
+```
+# Outcome
+The codebase has the data + crypto primitives needed to authenticate
+users with username + password, with no UI yet.
+
+# Acceptance criteria
+- A `users` table exists with: `id`, `email` (unique, indexed),
+  `password_hash`, `created_at`, `updated_at`.
+- A `sessions` table exists with: `id`, `user_id` (FK → users.id),
+  `expires_at`, `created_at`.
+- A `hashPassword(plain) -> hashed` utility uses bcrypt with cost 12.
+- A `verifyPassword(plain, hashed) -> bool` utility round-trips.
+- A `createSession(userId) -> sessionId` utility writes to the table.
+- A `getActiveSession(sessionId) -> Session | null` reads and respects
+  `expires_at`.
+
+# Scope boundaries
+- **In:** schema migrations, password hashing, session create/read.
+- **NOT in:** any HTTP routes, any UI, email confirmation (issue #3),
+  session invalidation / logout (issue #4), OAuth (issue #6).
+
+# File / area pointers
+- `db/migrations/` for the schema migrations.
+- `internal/auth/password.{go,ts,py}` for hashing utils.
+- `internal/auth/session.{go,ts,py}` for session CRUD.
+
+# Test expectations
+- Migration up + down round-trips cleanly.
+- `verifyPassword(p, hashPassword(p))` returns true.
+- `verifyPassword("wrong", hashPassword(p))` returns false.
+- `getActiveSession` returns null after `expires_at` passes.
+- All `go test ./internal/auth/...` (or equivalent) pass.
+```
+
+The body is dense, but every section earns its keep — the runner agent
+has no way to ask follow-up questions, so this is everything it gets.
+
+### Building the DAG
+
+In sequence:
+
+```
+klanky issue add --project auth \
+  --title "Auth backend skeleton" \
+  --body-file .docs/issues/auth-backend-skeleton.md
+# → created issue #1
+
+klanky issue add --project auth \
+  --title "User-pass signup + login UI" \
+  --body-file .docs/issues/auth-userpass-ui.md \
+  --depends-on 1
+# → created issue #2
+
+klanky issue add --project auth \
+  --title "Account confirmation email flow" \
+  --body-file .docs/issues/auth-confirm-email.md \
+  --depends-on 1
+# → created issue #3
+
+# ... and so on, each with the correct --depends-on numbers
+```
+
+Verify on the board:
+
+```
+klanky project list
+# visit the URL for slug=auth and confirm the DAG looks right
+```
+
+Now the project is ready. The user runs `klanky run --project auth` to
+spawn agents against unblocked issues.

--- a/skills/klanky-project/SKILL.md
+++ b/skills/klanky-project/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: klanky-project
+description: Create, link, and inspect klanky projects. One klanky project equals one workstream's GitHub Project v2 board, and a repo can host many. Use when a user wants to start a new klanky-managed initiative, link an existing GitHub Project to klanky, list registered projects, or understand what a klanky project is. Teaches the project schema (Status field + klanky:tracked label + GH-native blocked-by deps) and the new-vs-link decision.
+---
+
+# klanky-project
+
+A **klanky project** is one GitHub Projects v2 board scoped to one
+workstream or initiative. A repo can have many klanky projects — they
+keep parallel workstreams from crowding each other on a single kanban
+board, and the runner operates on one project at a time
+(`klanky run --project <slug>`).
+
+## What's in a project
+
+Every klanky project has three required components on the GitHub side:
+
+1. **A `Status` single-select field** with the values `Todo`,
+   `In Progress`, and `Done`. Klanky reads and writes this to track issue
+   lifecycle.
+2. **A `klanky:tracked` repo-level label.** This label is the *allowlist* —
+   klanky only acts on issues that carry it. Issues without the label are
+   invisible to klanky, even if they're on the board.
+3. **GitHub-native `blocked by` issue relations.** Klanky uses these as
+   DAG edges. A tracked issue is *eligible* for the runner only when all
+   of its `blocked by` issues are closed.
+
+Together, these make the GitHub board itself the contract — klanky stores
+no shadow state of its own about issue status or dependencies. If you can
+read the board, you can predict what klanky will do.
+
+## Slug rules
+
+Every klanky project has a **slug** that you pass to all project-scoped
+commands (`--project <slug>`). It's also embedded in branch paths
+(`klanky/<slug>/issue-<N>`), so it must be filesystem-and-git-safe.
+
+- Charset: `[a-z0-9-]+`.
+- Stable: pick something you won't want to rename. The slug is a permanent
+  identifier locally; renames mean editing `.klankyrc.json` and migrating
+  branch names by hand.
+- Short: it shows up in branch names and CLI flags. `auth` beats
+  `authentication-system-rewrite-2026`.
+
+## The new-vs-link decision
+
+| Situation | Command |
+|---|---|
+| No board exists yet for this workstream. Klanky should create a fresh, conformant one. | `klanky project new --slug <s> --title "..." --owner @me` |
+| A board already exists on GitHub (someone made it, or it predates klanky). | `klanky project link <project-url> --slug <s>` |
+
+`project new` creates the board with the required schema baked in: Status
+field, `klanky:tracked` label, ready to go.
+
+`project link` validates the existing board against the schema. If the
+board is missing the Status field with the right values, or the
+`klanky:tracked` label, link will tell you what's missing and exit. Fix
+the board on GitHub, then re-run.
+
+When in doubt, prefer `project new`. Linking is for cases where humans on
+the team are already using a board you want to keep.
+
+## List
+
+```
+klanky project list
+```
+
+Prints every project registered in `.klankyrc.json` with slug, title, and
+GitHub Project URL. Use this to confirm registration after `new` or
+`link`, or to remind yourself what slugs exist.
+
+## Inline example
+
+Starting an `auth` initiative in a freshly-bootstrapped repo:
+
+```
+$ klanky project new --slug auth --title "Auth System" --owner @me
+created project: https://github.com/users/jp/projects/12
+registered slug: auth
+schema: ✓ Status field, ✓ klanky:tracked label
+
+$ klanky project list
+SLUG  TITLE        URL
+auth  Auth System  https://github.com/users/jp/projects/12
+```
+
+The `auth` project is now ready. It's empty — no issues yet. The next
+step is populating it with a sized, dep'd issue DAG.
+
+## Next step
+
+Hand off to the `klanky-plan` skill. Given a workstream description, it
+walks through decomposing it into right-sized tracked issues with proper
+dependencies and runner-ready bodies, then calls `klanky issue add` for
+each.


### PR DESCRIPTION
## Summary

- Adds `skills/` at the repo root containing three single-file skills (`klanky-init`, `klanky-project`, `klanky-plan`) with valid YAML frontmatter, plus a `skills/README.md` index.
- These install into any consumer repo via `npx skills add joshuapeters/klanky` (the open agent-skills CLI), landing under `.claude/skills/<name>/`.
- Documents the bundle from the top-level `README.md` (new "Skills" section) and `AGENTS.md` (note that `skills/` is the published consumer-facing bundle, not contributor guidance).

Implements the plan at `.docs/superpowers/plans/2026-05-02-klanky-skills.md`.

## Test Plan

- [x] `npx skills add ./skills --list` — discovers all three skills with their descriptions.
- [x] `npx skills add /Users/jp/Source/klanky/skills --copy --yes -a claude-code` into a throwaway `/tmp/klanky-skills-verify-*` repo — installs all three under `.claude/skills/` with the expected `name:` frontmatter.
- [x] `go test ./...` — all packages pass (no Go code changed).
- [ ] Sanity check: skim each `SKILL.md` for content accuracy against current klanky CLI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)