### PR TITLE
fix(project new): patch Status field options instead of erroring

### DIFF
--- a/internal/cmd/project/new/new.go
+++ b/internal/cmd/project/new/new.go
@@ -1,8 +1,9 @@
 // Package new implements `klanky project new --slug X --title Y`. It creates a
 // fresh Projects v2 board (linking it to this repo) and registers it in
-// .klankyrc.json under the given slug. The Status single-select field is
-// auto-created by GitHub with the five required options; we only need to
-// fetch the field's resolved IDs and persist the name→optionId map.
+// .klankyrc.json under the given slug. GitHub's createProjectV2 only seeds the
+// Status field with three options (Todo / In Progress / Done); we patch in the
+// remaining two (In Review, Needs Attention) before persisting the resolved
+// option IDs.
 package newcmd
 
 import (
@@ -84,7 +85,14 @@ func RunProjectNew(ctx context.Context, r gh.Runner, opts Options, out io.Writer
 		return fmt.Errorf("fetch auto-created Status field: %w", err)
 	}
 	if missing := missingStatusOptions(statusField.Options); len(missing) > 0 {
-		return fmt.Errorf("auto-created Status field is missing options %v — GitHub schema may have changed", missing)
+		patched, err := patchStatusFieldOptions(ctx, r, statusField.ID)
+		if err != nil {
+			return fmt.Errorf("add missing Status options %v: %w", missing, err)
+		}
+		statusField = patched
+		if still := missingStatusOptions(statusField.Options); len(still) > 0 {
+			return fmt.Errorf("Status field still missing options %v after patch", still)
+		}
 	}
 
 	if err := ghx.EnsureTrackedLabel(ctx, r, cfg.Repo.Slug()); err != nil {
@@ -240,6 +248,48 @@ func fetchStatusField(ctx context.Context, r gh.Runner, projectID string) (*stat
 		return nil, fmt.Errorf("project has no Status single-select field")
 	}
 	out := resp.Node.Field
+	return &out, nil
+}
+
+// patchStatusOptionsMutation rewrites the Status field's singleSelectOptions to
+// klanky's canonical 5. New IDs are minted for every option, including the
+// three GitHub auto-created. That's safe here because `klanky project new`
+// runs immediately after createProjectV2, before any items reference an
+// option ID.
+const patchStatusOptionsMutation = `mutation($fieldId: ID!) {
+  updateProjectV2Field(input: {
+    fieldId: $fieldId
+    singleSelectOptions: [
+      {name: "Todo", color: GRAY, description: ""},
+      {name: "In Progress", color: YELLOW, description: ""},
+      {name: "In Review", color: BLUE, description: ""},
+      {name: "Needs Attention", color: RED, description: ""},
+      {name: "Done", color: GREEN, description: ""}
+    ]
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField {
+        id
+        name
+        options { id name }
+      }
+    }
+  }
+}`
+
+func patchStatusFieldOptions(ctx context.Context, r gh.Runner, fieldID string) (*statusField, error) {
+	var resp struct {
+		UpdateProjectV2Field struct {
+			ProjectV2Field statusField `json:"projectV2Field"`
+		} `json:"updateProjectV2Field"`
+	}
+	if err := gh.RunGraphQL(ctx, r, patchStatusOptionsMutation, map[string]any{"fieldId": fieldID}, &resp); err != nil {
+		return nil, err
+	}
+	if resp.UpdateProjectV2Field.ProjectV2Field.ID == "" {
+		return nil, fmt.Errorf("updateProjectV2Field returned empty field")
+	}
+	out := resp.UpdateProjectV2Field.ProjectV2Field
 	return &out, nil
 }
 

--- a/internal/cmd/project/new/new_test.go
+++ b/internal/cmd/project/new/new_test.go
@@ -171,6 +171,79 @@ func TestRunProjectNew_HappyPath_AtMe(t *testing.T) {
 	}
 }
 
+func TestRunProjectNew_PatchesStatusWhenGitHubAutoCreatesOnly3Options(t *testing.T) {
+	// GitHub's createProjectV2 only auto-seeds Todo / In Progress / Done. klanky
+	// must add the remaining two options itself rather than rejecting the
+	// just-created project (which would orphan the board on GitHub).
+	cfgPath := seedConfig(t)
+
+	fake := gh.NewFakeRunner()
+	stubViewer(fake, "joshuapeters", "U_owner")
+	stubRepoID(fake, "joshuapeters", "klanky", "R_repo")
+	stubCreate(fake, "U_owner", "Auth", "R_repo",
+		"PVT_new", 12, "https://github.com/users/joshuapeters/projects/12")
+	fake.Stub(
+		[]string{"gh", "api", "graphql",
+			"-f", "query=" + statusFieldQuery,
+			"-f", "pid=PVT_new"},
+		[]byte(`{"data":{"node":{"field":{
+			"id":"PVTSSF_status",
+			"name":"Status",
+			"options":[
+				{"id":"old_todo","name":"Todo"},
+				{"id":"old_inp","name":"In Progress"},
+				{"id":"old_done","name":"Done"}
+			]
+		}}}}`),
+		nil,
+	)
+	fake.Stub(
+		[]string{"gh", "api", "graphql",
+			"-f", "query=" + patchStatusOptionsMutation,
+			"-f", "fieldId=PVTSSF_status"},
+		[]byte(`{"data":{"updateProjectV2Field":{"projectV2Field":{
+			"id":"PVTSSF_status",
+			"name":"Status",
+			"options":[
+				{"id":"new_todo","name":"Todo"},
+				{"id":"new_inp","name":"In Progress"},
+				{"id":"new_inr","name":"In Review"},
+				{"id":"new_na","name":"Needs Attention"},
+				{"id":"new_done","name":"Done"}
+			]
+		}}}}`),
+		nil,
+	)
+	stubLabelMissing(fake, "joshuapeters/klanky")
+
+	err := RunProjectNew(context.Background(), fake, Options{
+		Slug: "auth", Title: "Auth", Owner: "@me", ConfigPath: cfgPath,
+	}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("RunProjectNew: %v", err)
+	}
+
+	cfg, err := config.LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	p, ok := cfg.Projects["auth"]
+	if !ok {
+		t.Fatalf("expected slug 'auth' in config, got %v", cfg.Projects)
+	}
+	for _, want := range config.StatusOptions {
+		if _, ok := p.Fields.Status.Options[want]; !ok {
+			t.Errorf("Status options missing %q (got %v)", want, p.Fields.Status.Options)
+		}
+	}
+	if got := p.Fields.Status.Options["In Review"]; got != "new_inr" {
+		t.Errorf("Status options[In Review] = %q (want new_inr)", got)
+	}
+	if got := p.Fields.Status.Options["Needs Attention"]; got != "new_na" {
+		t.Errorf("Status options[Needs Attention] = %q (want new_na)", got)
+	}
+}
+
 func TestRunProjectNew_RejectsDuplicateSlug(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, ".klankyrc.json")


### PR DESCRIPTION
## Summary

`klanky project new` was rejecting every freshly-created GitHub Project v2 board because GitHub's `createProjectV2` mutation only auto-seeds three Status options (`Todo` / `In Progress` / `Done`), while klanky requires five. The error message blamed a "GitHub schema change," but this has always been GitHub's documented default.

After the failure, the project was already created on GitHub — leaving an orphan board the user had to clean up or `project link` manually.

## Fix

When `fetchStatusField` returns a Status field missing any of klanky's canonical 5 options, issue an `updateProjectV2Field` mutation that sets `singleSelectOptions` to the full 5 (Todo, In Progress, In Review, Needs Attention, Done) with their canonical colors. The mutation response gives us the resolved option IDs, which populate `cfg.Projects[slug].Fields.Status.Options` exactly as before.

Because `project new` runs the patch immediately after `createProjectV2`, no project items can yet reference the auto-created option IDs, so the simpler "mint new IDs for all five" approach is safe (no preservation of the original three IDs needed).

## Test plan

- [x] New TDD test `TestRunProjectNew_PatchesStatusWhenGitHubAutoCreatesOnly3Options` — stubs the realistic 3-option auto-create response, asserts the patch mutation fires and all 5 options end up in config
- [x] Existing happy-path test (already-5-options) still passes; no patch call when nothing is missing
- [x] `go test ./...` clean
- [x] `go vet ./...` and `gofmt` clean

Closes #29