### PR TITLE
chore: bump feat as patch pre-1.0, keep breaking as minor

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,7 +3,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": false,
+  "bump-patch-for-minor-pre-major": true,
   "draft": false,
   "prerelease": false,
   "packages": {


### PR DESCRIPTION
## Summary
- Flip `bump-patch-for-minor-pre-major` to `true` so `feat:` PRs bump patch instead of minor while pre-1.0
- `bump-minor-pre-major: true` was already set, so `feat!:` / `BREAKING CHANGE` continues to bump minor (not major)

Net mapping while < 1.0.0:
- `fix:` → patch
- `feat:` → patch
- `feat!:` → minor

Note: both `bump-*-pre-major` flags are no-ops once we cross 1.0.0; at that point standard semver kicks back in.

## Test plan
- [ ] release-please PR opened by the next merged `feat:` bumps the patch component (e.g. 0.1.0 → 0.1.1)
- [ ] release-please PR opened by the next merged `feat!:` bumps the minor component (e.g. 0.1.0 → 0.2.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)