### PR TITLE
test: adopt go-cmp across remaining test files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/joshuapeters/klanky
 go 1.26.2
 
 require (
+	github.com/google/go-cmp v0.7.0
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/sync v0.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/joshuapeters/klanky/internal/gh"
+	"github.com/joshuapeters/klanky/internal/snapshot"
 )
 
 // fakeSpawner records the spawn invocation and returns a stubbed exit code/err.
@@ -57,8 +60,16 @@ func TestRunAgent_HappyPath_InReview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunAgent: %v", err)
 	}
-	if res.Outcome != OutcomeInReview || res.PR == nil || res.PR.Number != 99 {
-		t.Errorf("got %+v", res)
+	want := &Result{
+		IssueNumber: 42,
+		Outcome:     OutcomeInReview,
+		PR: &snapshot.PR{
+			Number: 99, URL: "https://x", State: "OPEN",
+			HeadRefName: "klanky/auth/issue-42",
+		},
+	}
+	if diff := cmp.Diff(want, res, cmpopts.IgnoreFields(Result{}, "StartedAt", "Duration")); diff != "" {
+		t.Errorf("Result mismatch (-want +got):\n%s", diff)
 	}
 	if sp.gotName != "claude" {
 		t.Errorf("spawned %q, want claude", sp.gotName)

--- a/internal/cmd/init/init_test.go
+++ b/internal/cmd/init/init_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/joshuapeters/klanky/internal/config"
 	"github.com/joshuapeters/klanky/internal/gh"
 )
@@ -106,22 +107,24 @@ func TestRunInit_AutoDetectFails(t *testing.T) {
 }
 
 func TestParseGitRemote(t *testing.T) {
-	cases := map[string][2]string{
-		"https://github.com/joshuapeters/klanky.git":  {"joshuapeters", "klanky"},
-		"https://github.com/joshuapeters/klanky":      {"joshuapeters", "klanky"},
-		"git@github.com:joshuapeters/klanky.git":      {"joshuapeters", "klanky"},
-		"git@github.com:joshuapeters/klanky":          {"joshuapeters", "klanky"},
-		"ssh://git@github.com/joshuapeters/klanky.git": {"joshuapeters", "klanky"},
-	}
-	for in, want := range cases {
-		o, n, err := parseGitRemote(in)
-		if err != nil {
-			t.Errorf("parseGitRemote(%q) error: %v", in, err)
-			continue
-		}
-		if o != want[0] || n != want[1] {
-			t.Errorf("parseGitRemote(%q) = (%q, %q), want %v", in, o, n, want)
-		}
+	type ownerName struct{ Owner, Name string }
+	want := ownerName{Owner: "joshuapeters", Name: "klanky"}
+	for _, in := range []string{
+		"https://github.com/joshuapeters/klanky.git",
+		"https://github.com/joshuapeters/klanky",
+		"git@github.com:joshuapeters/klanky.git",
+		"git@github.com:joshuapeters/klanky",
+		"ssh://git@github.com/joshuapeters/klanky.git",
+	} {
+		t.Run(in, func(t *testing.T) {
+			o, n, err := parseGitRemote(in)
+			if err != nil {
+				t.Fatalf("parseGitRemote: %v", err)
+			}
+			if diff := cmp.Diff(want, ownerName{Owner: o, Name: n}); diff != "" {
+				t.Errorf("parseGitRemote (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/issue/add/add_test.go
+++ b/internal/cmd/issue/add/add_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/joshuapeters/klanky/internal/config"
 	"github.com/joshuapeters/klanky/internal/gh"
 )
@@ -145,25 +146,13 @@ func TestParseDependsOn(t *testing.T) {
 			t.Errorf("parseDependsOn(%q) error: %v", in, err)
 			continue
 		}
-		if !slicesEqualInt(got, want) {
-			t.Errorf("parseDependsOn(%q) = %v, want %v", in, got, want)
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("parseDependsOn(%q) (-want +got):\n%s", in, diff)
 		}
 	}
 	if _, err := parseDependsOn("12,abc,5"); err == nil {
 		t.Errorf("expected error for non-integer token")
 	}
-}
-
-func slicesEqualInt(a, b []int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func TestRunIssueAdd_HappyPath_NoDeps(t *testing.T) {
@@ -277,7 +266,14 @@ func TestRunIssueAdd_JSONOutput(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
 		t.Fatalf("parse JSON: %v\n%s", err, out.String())
 	}
-	if got.Number != 42 || got.NodeID != "I_42" || got.Status != "Todo" {
-		t.Errorf("got %+v", got)
+	want := Result{
+		Number: 42,
+		URL:    "https://github.com/joshuapeters/klanky/issues/42",
+		NodeID: "I_42",
+		ItemID: "PVTI_42",
+		Status: "Todo",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Result mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/cmd/project/link/link_test.go
+++ b/internal/cmd/project/link/link_test.go
@@ -7,37 +7,42 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/joshuapeters/klanky/internal/config"
 	"github.com/joshuapeters/klanky/internal/gh"
 )
 
 func TestParseProjectURL(t *testing.T) {
+	type parsed struct {
+		Owner     string
+		Number    int
+		OwnerType string
+	}
 	cases := []struct {
-		in        string
-		owner     string
-		number    int
-		ownerType string
-		wantErr   bool
+		in      string
+		want    parsed
+		wantErr bool
 	}{
-		{"https://github.com/users/joshuapeters/projects/4", "joshuapeters", 4, "User", false},
-		{"https://github.com/orgs/wistia/projects/12/views/3", "wistia", 12, "Organization", false},
-		{"https://github.com/repos/x/y/issues/1", "", 0, "", true},
-		{"https://github.com/orgs/wistia/projects/abc", "", 0, "", true},
-		{"not-a-url", "", 0, "", true},
+		{"https://github.com/users/joshuapeters/projects/4", parsed{"joshuapeters", 4, "User"}, false},
+		{"https://github.com/orgs/wistia/projects/12/views/3", parsed{"wistia", 12, "Organization"}, false},
+		{"https://github.com/repos/x/y/issues/1", parsed{}, true},
+		{"https://github.com/orgs/wistia/projects/abc", parsed{}, true},
+		{"not-a-url", parsed{}, true},
 	}
 	for _, c := range cases {
-		owner, number, ownerType, err := ParseProjectURL(c.in)
-		if (err != nil) != c.wantErr {
-			t.Errorf("ParseProjectURL(%q) err = %v, wantErr %v", c.in, err, c.wantErr)
-			continue
-		}
-		if c.wantErr {
-			continue
-		}
-		if owner != c.owner || number != c.number || ownerType != c.ownerType {
-			t.Errorf("ParseProjectURL(%q) = (%q, %d, %q), want (%q, %d, %q)",
-				c.in, owner, number, ownerType, c.owner, c.number, c.ownerType)
-		}
+		t.Run(c.in, func(t *testing.T) {
+			owner, number, ownerType, err := ParseProjectURL(c.in)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, c.wantErr)
+			}
+			if c.wantErr {
+				return
+			}
+			got := parsed{Owner: owner, Number: number, OwnerType: ownerType}
+			if diff := cmp.Diff(c.want, got); diff != "" {
+				t.Errorf("ParseProjectURL (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -148,14 +153,26 @@ func TestRunProjectLink_HappyPath(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected slug 'auth-system' in config, got %v", cfg.Projects)
 	}
-	if p.NodeID != "PVT_abc" {
-		t.Errorf("NodeID = %q", p.NodeID)
+	want := config.Project{
+		URL:        "https://github.com/users/joshuapeters/projects/4",
+		Number:     4,
+		NodeID:     "PVT_abc",
+		Title:      "Auth System",
+		OwnerLogin: "joshuapeters",
+		OwnerType:  "User",
+		Fields: config.ProjectFields{
+			Status: config.StatusField{
+				ID: "PVTSSF_status", Name: "Status",
+				Options: map[string]string{
+					"Todo": "opt_todo", "In Progress": "opt_inp",
+					"In Review": "opt_inr", "Needs Attention": "opt_na",
+					"Done": "opt_done",
+				},
+			},
+		},
 	}
-	if p.Title != "Auth System" {
-		t.Errorf("Title = %q", p.Title)
-	}
-	if p.Fields.Status.Options["In Review"] != "opt_inr" {
-		t.Errorf("Status options[In Review] = %q", p.Fields.Status.Options["In Review"])
+	if diff := cmp.Diff(want, p); diff != "" {
+		t.Errorf("Project mismatch (-want +got):\n%s", diff)
 	}
 	if !strings.Contains(out.String(), "auth-system") || !strings.Contains(out.String(), "7") {
 		t.Errorf("expected slug + count in output, got %q", out.String())

--- a/internal/cmd/project/list/list_test.go
+++ b/internal/cmd/project/list/list_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/joshuapeters/klanky/internal/config"
 )
 
@@ -59,8 +60,9 @@ func TestRunProjectList_JSON(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
 		t.Fatalf("parse json: %v\n%s", err, out.String())
 	}
-	if len(got) != 1 || got[0]["slug"] != "auth" || got[0]["title"] != "Auth" {
-		t.Errorf("got %v", got)
+	want := []map[string]string{{"slug": "auth", "title": "Auth", "url": "https://x"}}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("project list (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/cmd/project/new/new_test.go
+++ b/internal/cmd/project/new/new_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/joshuapeters/klanky/internal/config"
 	"github.com/joshuapeters/klanky/internal/gh"
 )
@@ -157,14 +158,26 @@ func TestRunProjectNew_HappyPath_AtMe(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected slug 'auth' in config, got %v", cfg.Projects)
 	}
-	if p.NodeID != "PVT_new" || p.Number != 12 {
-		t.Errorf("project = %+v", p)
+	want := config.Project{
+		URL:        "https://github.com/users/joshuapeters/projects/12",
+		Number:     12,
+		NodeID:     "PVT_new",
+		Title:      "Auth System",
+		OwnerLogin: "joshuapeters",
+		OwnerType:  "User",
+		Fields: config.ProjectFields{
+			Status: config.StatusField{
+				ID: "PVTSSF_status", Name: "Status",
+				Options: map[string]string{
+					"Todo": "opt_todo", "In Progress": "opt_inp",
+					"In Review": "opt_inr", "Needs Attention": "opt_na",
+					"Done": "opt_done",
+				},
+			},
+		},
 	}
-	if p.OwnerLogin != "joshuapeters" || p.OwnerType != "User" {
-		t.Errorf("owner = (%q,%q)", p.OwnerLogin, p.OwnerType)
-	}
-	if p.Fields.Status.Options["In Review"] != "opt_inr" {
-		t.Errorf("Status options[In Review] = %q", p.Fields.Status.Options["In Review"])
+	if diff := cmp.Diff(want, p); diff != "" {
+		t.Errorf("Project mismatch (-want +got):\n%s", diff)
 	}
 	if !strings.Contains(out.String(), "auth") {
 		t.Errorf("expected slug in confirmation, got %q", out.String())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSaveLoadRoundTrip(t *testing.T) {
@@ -35,14 +37,8 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if got.SchemaVersion != SchemaVersion {
-		t.Errorf("SchemaVersion = %d, want %d", got.SchemaVersion, SchemaVersion)
-	}
-	if got.Repo.Slug() != "joshuapeters/klanky" {
-		t.Errorf("Repo.Slug() = %q", got.Repo.Slug())
-	}
-	if got.Projects["auth"].Fields.Status.Options["In Review"] != "3" {
-		t.Errorf("status options not round-tripped: %#v", got.Projects["auth"].Fields.Status.Options)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFakeRunner_RecordsCallAndReturnsStubbedOutput(t *testing.T) {
@@ -68,11 +70,11 @@ func TestRunGraphQL_ParsesDataIntoTarget(t *testing.T) {
 	if err := RunGraphQL(context.Background(), fake, "QUERY", nil, &got); err != nil {
 		t.Fatalf("RunGraphQL: %v", err)
 	}
-	if got.Repository.Issue.Number != 117 {
-		t.Errorf("number = %d, want 117", got.Repository.Issue.Number)
-	}
-	if got.Repository.Issue.Title != "hi" {
-		t.Errorf("title = %q, want hi", got.Repository.Issue.Title)
+	var want result
+	want.Repository.Issue.Number = 117
+	want.Repository.Issue.Title = "hi"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("RunGraphQL result (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/joshuapeters/klanky/internal/snapshot"
 )
 
@@ -32,6 +34,10 @@ func itoa(n int) string {
 	return string(buf[i:])
 }
 
+// ignoreBreadcrumb compares Action values without asserting on the freeform
+// breadcrumb text — tests that care assert on it separately.
+var ignoreBreadcrumb = cmpopts.IgnoreFields(Action{}, "Breadcrumb")
+
 func find(actions []Action, num int) *Action {
 	for i := range actions {
 		if actions[i].IssueNumber == num {
@@ -47,21 +53,19 @@ func TestRow1_ClosedIssueGoesToDone(t *testing.T) {
 		issue(2, "CLOSED", "Done"), // already Done — no action
 		issue(3, "CLOSED", ""),
 	}, nil))
-	if a := find(got, 1); a == nil || a.NewStatus != "Done" {
-		t.Errorf("issue 1 → %+v, want Done", a)
+	want := []Action{
+		{IssueNumber: 1, ItemID: "PVTI_1", NewStatus: "Done"},
+		{IssueNumber: 3, ItemID: "PVTI_3", NewStatus: "Done"},
 	}
-	if a := find(got, 2); a != nil {
-		t.Errorf("issue 2 already Done; expected no action, got %+v", a)
-	}
-	if a := find(got, 3); a == nil || a.NewStatus != "Done" {
-		t.Errorf("issue 3 → %+v, want Done", a)
+	if diff := cmp.Diff(want, got, ignoreBreadcrumb); diff != "" {
+		t.Errorf("actions mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestRow2_TodoIsNoOp(t *testing.T) {
 	got := Reconcile(snap("auth", []snapshot.Issue{issue(1, "OPEN", "Todo")}, nil))
-	if len(got) != 0 {
-		t.Errorf("expected no actions, got %v", got)
+	if diff := cmp.Diff([]Action(nil), got); diff != "" {
+		t.Errorf("expected no actions (-want +got):\n%s", diff)
 	}
 }
 
@@ -81,8 +85,9 @@ func TestRow4_InProgressWithOpenPRGoesToInReview(t *testing.T) {
 		snapshot.BranchForIssue("auth", 7): {Number: 99, State: "OPEN", URL: "x", HeadRefName: snapshot.BranchForIssue("auth", 7)},
 	}
 	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Progress")}, prs))
-	if a := find(got, 7); a == nil || a.NewStatus != "In Review" {
-		t.Errorf("got %+v, want In Review", a)
+	want := []Action{{IssueNumber: 7, ItemID: "PVTI_7", NewStatus: "In Review"}}
+	if diff := cmp.Diff(want, got, ignoreBreadcrumb); diff != "" {
+		t.Errorf("actions mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -91,8 +96,8 @@ func TestRow6_InReviewWithOpenPRIsNoOp(t *testing.T) {
 		snapshot.BranchForIssue("auth", 7): {Number: 99, State: "OPEN", HeadRefName: snapshot.BranchForIssue("auth", 7)},
 	}
 	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Review")}, prs))
-	if len(got) != 0 {
-		t.Errorf("expected no actions, got %v", got)
+	if diff := cmp.Diff([]Action(nil), got); diff != "" {
+		t.Errorf("expected no actions (-want +got):\n%s", diff)
 	}
 }
 
@@ -123,8 +128,8 @@ func TestRow8_InReviewWithoutPRGoesToNeedsAttention(t *testing.T) {
 
 func TestRow9_NeedsAttentionIsNoOp(t *testing.T) {
 	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "Needs Attention")}, nil))
-	if len(got) != 0 {
-		t.Errorf("expected no actions, got %v", got)
+	if diff := cmp.Diff([]Action(nil), got); diff != "" {
+		t.Errorf("expected no actions (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/joshuapeters/klanky/internal/agent"
 	"github.com/joshuapeters/klanky/internal/config"
 	"github.com/joshuapeters/klanky/internal/gh"
@@ -44,8 +45,9 @@ func TestSelectWork_Eligible(t *testing.T) {
 	if scenario != nil {
 		t.Fatalf("unexpected scenario: %v", scenario)
 	}
-	if len(got) != 2 || got[0].Number != 1 || got[1].Number != 2 {
-		t.Errorf("eligible = %v", got)
+	want := []snapshot.Issue{openIssue(1, "Todo"), openIssue(2, "Needs Attention")}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("eligible (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/joshuapeters/klanky/internal/config"
 	"github.com/joshuapeters/klanky/internal/gh"
 )
@@ -71,29 +72,30 @@ func TestFetch_FiltersUntrackedAndExtractsBlockers(t *testing.T) {
 		nil,
 	)
 
-	snap, err := Fetch(context.Background(), fake, cfg, "auth", nil)
+	got, err := Fetch(context.Background(), fake, cfg, "auth", nil)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
-	if len(snap.Issues) != 1 || snap.Issues[0].Number != 42 {
-		t.Fatalf("expected 1 tracked issue (#42); got %d", len(snap.Issues))
+
+	want := &Snapshot{
+		ProjectSlug: "auth",
+		Issues: []Issue{{
+			Number: 42, Title: "Login UI", Body: "do the thing",
+			State: "OPEN", ItemID: "PVTI_1", Status: "Todo",
+			BlockedBy: []Blocker{
+				{Number: 7, State: "CLOSED", Repo: "joshuapeters/klanky"},
+				{Number: 9, State: "OPEN", Repo: "someone/else"},
+			},
+		}},
+		PRsByBranch: map[string]PR{
+			BranchForIssue("auth", 42): {
+				Number: 99, URL: "https://x", State: "OPEN",
+				HeadRefName: "klanky/auth/issue-42",
+			},
+		},
 	}
-	got := snap.Issues[0]
-	if got.Title != "Login UI" || got.Status != "Todo" || got.Body != "do the thing" {
-		t.Errorf("got %+v", got)
-	}
-	if len(got.BlockedBy) != 2 {
-		t.Fatalf("blockers = %d, want 2", len(got.BlockedBy))
-	}
-	if got.BlockedBy[0].Number != 7 || got.BlockedBy[0].State != "CLOSED" {
-		t.Errorf("blocker0 = %+v", got.BlockedBy[0])
-	}
-	if got.BlockedBy[1].Repo != "someone/else" {
-		t.Errorf("cross-repo blocker missing repo: %+v", got.BlockedBy[1])
-	}
-	pr, ok := snap.PRsByBranch[BranchForIssue("auth", 42)]
-	if !ok || pr.Number != 99 {
-		t.Errorf("expected PR #99 indexed by branch klanky/auth/issue-42; got %v", snap.PRsByBranch)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("snapshot mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Builds on b613178 (go-cmp for config round-trip) by applying the same pattern to the rest of the test suite where struct/slice/map deep-equality reads better than hand-rolled field checks.
- Drops the bespoke `slicesEqualInt` helper in `cmd/issue/add`; uses `cmpopts.IgnoreFields` in reconcile tests to skip the freeform breadcrumb where tests don't assert on it.
- Leaves string-contains, error-message, and single-string equality checks alone — `cmp.Diff` doesn't help there.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`