### PR TITLE
refactor: centralize string identifier construction in identifiers package

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -45,6 +45,7 @@ type Job struct {
 	IssueNumber  int
 	IssueTitle   string
 	IssueBody    string
+	Branch       string
 	WorktreePath string
 	LogPath      string
 	RepoSlug     string // owner/name
@@ -129,6 +130,7 @@ func RunAgent(ctx context.Context, r gh.Runner, sp Spawner, job Job) (*Result, e
 		IssueTitle:   job.IssueTitle,
 		IssueBody:    job.IssueBody,
 		ProjectSlug:  job.ProjectSlug,
+		Branch:       job.Branch,
 		WorktreePath: job.WorktreePath,
 	})
 
@@ -169,7 +171,7 @@ func RunAgent(ctx context.Context, r gh.Runner, sp Spawner, job Job) (*Result, e
 		return res, nil
 	}
 
-	branch := snapshot.BranchForIssue(job.ProjectSlug, job.IssueNumber)
+	branch := job.Branch
 	prOut, prErr := r.Run(ctx, "gh", "pr", "list",
 		"--repo", job.RepoSlug,
 		"--head", branch, "--state", "open",

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -36,6 +36,7 @@ func newJob(t *testing.T) Job {
 	return Job{
 		ProjectSlug: "auth",
 		IssueNumber: 42, IssueTitle: "Login UI", IssueBody: "do it",
+		Branch:       "klanky/auth/issue-42",
 		WorktreePath: dir,
 		LogPath:      filepath.Join(dir, "issue.log"),
 		RepoSlug:     "joshuapeters/klanky",

--- a/internal/agent/envelope.go
+++ b/internal/agent/envelope.go
@@ -5,22 +5,22 @@ package agent
 
 import "fmt"
 
-// EnvelopeData are the substitution inputs for the prompt template. Five
-// fields, all required.
+// EnvelopeData are the substitution inputs for the prompt template. All
+// fields are required.
 type EnvelopeData struct {
 	IssueNumber  int
 	IssueTitle   string
 	IssueBody    string
 	ProjectSlug  string
+	Branch       string
 	WorktreePath string
 }
 
 // envelopeTemplate is the verbatim template from project_envelope_contract.md.
-// The five `%s`/`%d` substitutions are filled by BuildEnvelope. Any visible
-// drift from the locked contract is a bug.
+// Any visible drift from the locked contract is a bug.
 const envelopeTemplate = "You are working on issue #%d in project `%s`: %s\n" +
 	"\n" +
-	"You are in a git worktree at %s, on branch `klanky/%s/issue-%d`,\n" +
+	"You are in a git worktree at %s, on branch `%s`,\n" +
 	"branched from `main`. Do all your work here. Do not push or modify any other branch.\n" +
 	"\n" +
 	"# Issue\n" +
@@ -58,7 +58,7 @@ const envelopeTemplate = "You are working on issue #%d in project `%s`: %s\n" +
 	"\n" +
 	"# Constraints\n" +
 	"\n" +
-	"- Do not push to any branch other than `klanky/%s/issue-%d`.\n" +
+	"- Do not push to any branch other than `%s`.\n" +
 	"- Do not merge any PR.\n" +
 	"- Do not modify other open issues or the project board.\n"
 
@@ -66,10 +66,10 @@ const envelopeTemplate = "You are working on issue #%d in project `%s`: %s\n" +
 func BuildEnvelope(d EnvelopeData) string {
 	return fmt.Sprintf(envelopeTemplate,
 		d.IssueNumber, d.ProjectSlug, d.IssueTitle, // header
-		d.WorktreePath, d.ProjectSlug, d.IssueNumber, // worktree + branch
-		d.IssueBody,                                  // # Issue
-		d.IssueNumber, d.IssueNumber,                  // two Closes #N
-		d.IssueNumber, d.IssueNumber,                  // give-up + retry-context
-		d.ProjectSlug, d.IssueNumber,                  // constraints branch
+		d.WorktreePath, d.Branch,                    // worktree + branch
+		d.IssueBody,                                 // # Issue
+		d.IssueNumber, d.IssueNumber,                // two Closes #N
+		d.IssueNumber, d.IssueNumber,                // give-up + retry-context
+		d.Branch,                                    // constraints branch
 	)
 }

--- a/internal/agent/envelope_test.go
+++ b/internal/agent/envelope_test.go
@@ -11,6 +11,7 @@ func TestBuildEnvelope_ContainsContract(t *testing.T) {
 		IssueTitle:   "Refactor login",
 		IssueBody:    "make it work",
 		ProjectSlug:  "auth",
+		Branch:       "klanky/auth/issue-42",
 		WorktreePath: "/tmp/wt",
 	})
 	wants := []string{
@@ -34,7 +35,7 @@ func TestBuildEnvelope_ContainsContract(t *testing.T) {
 func TestBuildEnvelope_DoesNotMentionV1Vocabulary(t *testing.T) {
 	got := BuildEnvelope(EnvelopeData{
 		IssueNumber: 1, IssueTitle: "x", IssueBody: "y",
-		ProjectSlug: "auth", WorktreePath: "/wt",
+		ProjectSlug: "auth", Branch: "klanky/auth/issue-1", WorktreePath: "/wt",
 	})
 	for _, banned := range []string{"feat-1", "task-", "feature ", "Phase"} {
 		if strings.Contains(got, banned) {

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/joshuapeters/klanky/internal/agent"
 	"github.com/joshuapeters/klanky/internal/config"
 	"github.com/joshuapeters/klanky/internal/gh"
+	"github.com/joshuapeters/klanky/internal/identifiers"
 	"github.com/joshuapeters/klanky/internal/runner"
 )
 
@@ -63,11 +64,14 @@ func RunRun(ctx context.Context, opts Options, stdout, stderr interface {
 		return err
 	}
 
+	ids := identifiers.New(stateRoot, cfg.Repo.Owner, cfg.Repo.Name, opts.ProjectSlug)
+
 	d := runner.Deps{
 		Runner:      gh.RealRunner{},
 		Spawner:     agent.RealSpawner{},
 		Config:      cfg,
 		ProjectSlug: opts.ProjectSlug,
+		Identifiers: ids,
 		RepoRoot:    repoRoot,
 		StateRoot:   stateRoot,
 		Output:      opts.Output,

--- a/internal/identifiers/identifiers.go
+++ b/internal/identifiers/identifiers.go
@@ -1,0 +1,58 @@
+// Package identifiers derives all per-project and per-issue string identifiers
+// (branch names, filesystem paths) from a fixed set of base arguments. Construct
+// one Identifiers per run; pass varying values (e.g. issue number) as method
+// parameters.
+package identifiers
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Identifiers derives all string identifiers for a klanky project. Construct
+// once and pass throughout the run.
+type Identifiers struct {
+	stateRoot string
+	owner     string
+	repo      string
+	slug      string
+}
+
+// New returns an Identifiers for the given project. owner and repo are
+// lowercased to match the directory layout.
+func New(stateRoot, owner, repo, slug string) Identifiers {
+	return Identifiers{
+		stateRoot: stateRoot,
+		owner:     strings.ToLower(owner),
+		repo:      strings.ToLower(repo),
+		slug:      slug,
+	}
+}
+
+// LockPath is the per-project file lock path.
+func (ids Identifiers) LockPath() string {
+	return filepath.Join(ids.stateRoot, "locks", ids.owner, ids.repo, ids.slug+".lock")
+}
+
+// BranchPrefix is the head-filter prefix used to query PRs for this project.
+func (ids Identifiers) BranchPrefix() string {
+	return fmt.Sprintf("klanky/%s/", ids.slug)
+}
+
+// Branch is the per-issue git branch name.
+func (ids Identifiers) Branch(issueNumber int) string {
+	return fmt.Sprintf("klanky/%s/issue-%d", ids.slug, issueNumber)
+}
+
+// WorktreePath is the per-issue git worktree path.
+func (ids Identifiers) WorktreePath(issueNumber int) string {
+	return filepath.Join(ids.stateRoot, "worktrees", ids.owner, ids.repo, ids.slug,
+		fmt.Sprintf("issue-%d", issueNumber))
+}
+
+// LogPath is the per-issue agent log path.
+func (ids Identifiers) LogPath(issueNumber int) string {
+	return filepath.Join(ids.stateRoot, "logs", ids.owner, ids.repo, ids.slug,
+		fmt.Sprintf("issue-%d.log", issueNumber))
+}

--- a/internal/identifiers/identifiers_test.go
+++ b/internal/identifiers/identifiers_test.go
@@ -1,0 +1,53 @@
+package identifiers_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/joshuapeters/klanky/internal/identifiers"
+)
+
+func TestIdentifiers(t *testing.T) {
+	ids := identifiers.New("/state", "Owner", "Repo", "auth")
+
+	t.Run("Branch", func(t *testing.T) {
+		if got := ids.Branch(42); got != "klanky/auth/issue-42" {
+			t.Errorf("Branch(42) = %q", got)
+		}
+	})
+
+	t.Run("BranchPrefix", func(t *testing.T) {
+		if got := ids.BranchPrefix(); got != "klanky/auth/" {
+			t.Errorf("BranchPrefix() = %q", got)
+		}
+	})
+
+	t.Run("WorktreePath", func(t *testing.T) {
+		want := filepath.Join("/state", "worktrees", "owner", "repo", "auth", "issue-42")
+		if got := ids.WorktreePath(42); got != want {
+			t.Errorf("WorktreePath(42) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("LogPath", func(t *testing.T) {
+		want := filepath.Join("/state", "logs", "owner", "repo", "auth", "issue-42.log")
+		if got := ids.LogPath(42); got != want {
+			t.Errorf("LogPath(42) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("LockPath", func(t *testing.T) {
+		want := filepath.Join("/state", "locks", "owner", "repo", "auth.lock")
+		if got := ids.LockPath(); got != want {
+			t.Errorf("LockPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("OwnerRepoLowercased", func(t *testing.T) {
+		upper := identifiers.New("/state", "JoshuaPeters", "Klanky", "auth")
+		want := filepath.Join("/state", "worktrees", "joshuapeters", "klanky", "auth", "issue-1")
+		if got := upper.WorktreePath(1); got != want {
+			t.Errorf("WorktreePath with uppercase owner/repo = %q, want %q", got, want)
+		}
+	})
+}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -8,17 +8,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 )
-
-// Path returns the lock file path for a (klanky-state-root, owner, repo, slug)
-// tuple. stateRoot is typically `~/.klanky`. owner and repo are lowercased to
-// match the directory layout.
-func Path(stateRoot, owner, repo, slug string) string {
-	return filepath.Join(stateRoot, "locks", strings.ToLower(owner), strings.ToLower(repo), slug+".lock")
-}
 
 // Lock represents a held klanky runner lock. Call Release on graceful
 // shutdown (typically via defer at the top of a run).

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -8,14 +8,6 @@ import (
 	"testing"
 )
 
-func TestPath_Lowercases(t *testing.T) {
-	got := Path("/root", "JoshuaPeters", "Klanky", "auth")
-	want := "/root/locks/joshuapeters/klanky/auth.lock"
-	if got != want {
-		t.Errorf("Path = %q, want %q", got, want)
-	}
-}
-
 func TestAcquire_FreshAndRelease(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "x.lock")

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/joshuapeters/klanky/internal/identifiers"
 	"github.com/joshuapeters/klanky/internal/snapshot"
 )
 
@@ -28,10 +29,10 @@ type Action struct {
 
 // Reconcile returns the list of state updates needed to align Status with
 // truth. Implements the rows from project_runner_design.md.
-func Reconcile(snap *snapshot.Snapshot) []Action {
+func Reconcile(snap *snapshot.Snapshot, ids identifiers.Identifiers) []Action {
 	var actions []Action
 	for _, issue := range snap.Issues {
-		branch := snapshot.BranchForIssue(snap.ProjectSlug, issue.Number)
+		branch := ids.Branch(issue.Number)
 		pr, hasPR := snap.PRsByBranch[branch]
 
 		// Row 1: closed issue → Done.

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -6,8 +6,15 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/joshuapeters/klanky/internal/identifiers"
 	"github.com/joshuapeters/klanky/internal/snapshot"
 )
+
+// testIDs returns an Identifiers for the given slug, suitable for tests that
+// don't need real filesystem paths.
+func testIDs(slug string) identifiers.Identifiers {
+	return identifiers.New("", "", "", slug)
+}
 
 func snap(slug string, issues []snapshot.Issue, prs map[string]snapshot.PR) *snapshot.Snapshot {
 	if prs == nil {
@@ -52,7 +59,7 @@ func TestRow1_ClosedIssueGoesToDone(t *testing.T) {
 		issue(1, "CLOSED", "In Progress"),
 		issue(2, "CLOSED", "Done"), // already Done — no action
 		issue(3, "CLOSED", ""),
-	}, nil))
+	}, nil), testIDs("auth"))
 	want := []Action{
 		{IssueNumber: 1, ItemID: "PVTI_1", NewStatus: "Done"},
 		{IssueNumber: 3, ItemID: "PVTI_3", NewStatus: "Done"},
@@ -63,14 +70,14 @@ func TestRow1_ClosedIssueGoesToDone(t *testing.T) {
 }
 
 func TestRow2_TodoIsNoOp(t *testing.T) {
-	got := Reconcile(snap("auth", []snapshot.Issue{issue(1, "OPEN", "Todo")}, nil))
+	got := Reconcile(snap("auth", []snapshot.Issue{issue(1, "OPEN", "Todo")}, nil), testIDs("auth"))
 	if diff := cmp.Diff([]Action(nil), got); diff != "" {
 		t.Errorf("expected no actions (-want +got):\n%s", diff)
 	}
 }
 
 func TestRow3_InProgressWithoutPRGoesToNeedsAttention(t *testing.T) {
-	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Progress")}, nil))
+	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Progress")}, nil), testIDs("auth"))
 	a := find(got, 7)
 	if a == nil || a.NewStatus != "Needs Attention" {
 		t.Fatalf("got %+v, want Needs Attention", a)
@@ -82,9 +89,9 @@ func TestRow3_InProgressWithoutPRGoesToNeedsAttention(t *testing.T) {
 
 func TestRow4_InProgressWithOpenPRGoesToInReview(t *testing.T) {
 	prs := map[string]snapshot.PR{
-		snapshot.BranchForIssue("auth", 7): {Number: 99, State: "OPEN", URL: "x", HeadRefName: snapshot.BranchForIssue("auth", 7)},
+		"klanky/auth/issue-7": {Number: 99, State: "OPEN", URL: "x", HeadRefName: "klanky/auth/issue-7"},
 	}
-	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Progress")}, prs))
+	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Progress")}, prs), testIDs("auth"))
 	want := []Action{{IssueNumber: 7, ItemID: "PVTI_7", NewStatus: "In Review"}}
 	if diff := cmp.Diff(want, got, ignoreBreadcrumb); diff != "" {
 		t.Errorf("actions mismatch (-want +got):\n%s", diff)
@@ -93,9 +100,9 @@ func TestRow4_InProgressWithOpenPRGoesToInReview(t *testing.T) {
 
 func TestRow6_InReviewWithOpenPRIsNoOp(t *testing.T) {
 	prs := map[string]snapshot.PR{
-		snapshot.BranchForIssue("auth", 7): {Number: 99, State: "OPEN", HeadRefName: snapshot.BranchForIssue("auth", 7)},
+		"klanky/auth/issue-7": {Number: 99, State: "OPEN", HeadRefName: "klanky/auth/issue-7"},
 	}
-	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Review")}, prs))
+	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Review")}, prs), testIDs("auth"))
 	if diff := cmp.Diff([]Action(nil), got); diff != "" {
 		t.Errorf("expected no actions (-want +got):\n%s", diff)
 	}
@@ -103,9 +110,9 @@ func TestRow6_InReviewWithOpenPRIsNoOp(t *testing.T) {
 
 func TestRow7_InReviewWithClosedPRGoesToNeedsAttention(t *testing.T) {
 	prs := map[string]snapshot.PR{
-		snapshot.BranchForIssue("auth", 7): {Number: 99, State: "CLOSED", HeadRefName: snapshot.BranchForIssue("auth", 7)},
+		"klanky/auth/issue-7": {Number: 99, State: "CLOSED", HeadRefName: "klanky/auth/issue-7"},
 	}
-	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Review")}, prs))
+	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Review")}, prs), testIDs("auth"))
 	a := find(got, 7)
 	if a == nil || a.NewStatus != "Needs Attention" {
 		t.Fatalf("got %+v", a)
@@ -116,7 +123,7 @@ func TestRow7_InReviewWithClosedPRGoesToNeedsAttention(t *testing.T) {
 }
 
 func TestRow8_InReviewWithoutPRGoesToNeedsAttention(t *testing.T) {
-	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Review")}, nil))
+	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "In Review")}, nil), testIDs("auth"))
 	a := find(got, 7)
 	if a == nil || a.NewStatus != "Needs Attention" {
 		t.Fatalf("got %+v", a)
@@ -127,14 +134,14 @@ func TestRow8_InReviewWithoutPRGoesToNeedsAttention(t *testing.T) {
 }
 
 func TestRow9_NeedsAttentionIsNoOp(t *testing.T) {
-	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "Needs Attention")}, nil))
+	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "Needs Attention")}, nil), testIDs("auth"))
 	if diff := cmp.Diff([]Action(nil), got); diff != "" {
 		t.Errorf("expected no actions (-want +got):\n%s", diff)
 	}
 }
 
 func TestRow10_OpenIssueWithDoneStatusGoesToNeedsAttention(t *testing.T) {
-	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "Done")}, nil))
+	got := Reconcile(snap("auth", []snapshot.Issue{issue(7, "OPEN", "Done")}, nil), testIDs("auth"))
 	a := find(got, 7)
 	if a == nil || a.NewStatus != "Needs Attention" {
 		t.Fatalf("got %+v", a)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/joshuapeters/klanky/internal/agent"
 	"github.com/joshuapeters/klanky/internal/config"
 	"github.com/joshuapeters/klanky/internal/gh"
+	"github.com/joshuapeters/klanky/internal/identifiers"
 	"github.com/joshuapeters/klanky/internal/lock"
 	"github.com/joshuapeters/klanky/internal/reconcile"
 	"github.com/joshuapeters/klanky/internal/snapshot"
@@ -42,6 +43,7 @@ type Deps struct {
 	Spawner     agent.Spawner
 	Config      *config.Config
 	ProjectSlug string
+	Identifiers identifiers.Identifiers
 	RepoRoot    string // absolute path to the main checkout
 	StateRoot   string // typically ~/.klanky
 	Output      string // "text" or "json"
@@ -79,7 +81,7 @@ func Run(ctx context.Context, d Deps) error {
 	}
 
 	// 1. Acquire lock.
-	lockPath := lock.Path(d.StateRoot, d.Config.Repo.Owner, d.Config.Repo.Name, d.ProjectSlug)
+	lockPath := d.Identifiers.LockPath()
 	lk, err := lock.Acquire(lockPath)
 	if err != nil {
 		return err
@@ -94,7 +96,7 @@ func Run(ctx context.Context, d Deps) error {
 	}
 
 	// 3. Reconcile (apply mutations to GH and snapshot).
-	actions := reconcile.Reconcile(snap)
+	actions := reconcile.Reconcile(snap, d.Identifiers)
 	d.applyReconcile(ctx, project, snap, actions)
 
 	// 4. Eligibility + nothing-to-do scenarios.
@@ -246,9 +248,9 @@ func selectWork(snap *snapshot.Snapshot) ([]snapshot.Issue, *scenarioMsg) {
 
 // runOne executes the per-issue lifecycle. Always returns a populated Result.
 func (d Deps) runOne(ctx context.Context, project config.Project, issue snapshot.Issue, repoSlug string) agent.Result {
-	wtPath := worktree.Path(d.StateRoot, d.Config.Repo.Owner, d.Config.Repo.Name, d.ProjectSlug, issue.Number)
-	logPath := worktree.LogPath(d.StateRoot, d.Config.Repo.Owner, d.Config.Repo.Name, d.ProjectSlug, issue.Number)
-	branch := snapshot.BranchForIssue(d.ProjectSlug, issue.Number)
+	wtPath := d.Identifiers.WorktreePath(issue.Number)
+	logPath := d.Identifiers.LogPath(issue.Number)
+	branch := d.Identifiers.Branch(issue.Number)
 
 	if err := worktree.EnsureClean(ctx, d.Runner, d.RepoRoot, wtPath, branch, "main"); err != nil {
 		return d.markEarlyFailure(ctx, project, repoSlug, issue, wtPath, logPath, fmt.Sprintf("worktree setup failed: %v", err))
@@ -261,7 +263,7 @@ func (d Deps) runOne(ctx context.Context, project config.Project, issue snapshot
 	res, err := agent.RunAgent(ctx, d.Runner, d.Spawner, agent.Job{
 		ProjectSlug: d.ProjectSlug,
 		IssueNumber: issue.Number, IssueTitle: issue.Title, IssueBody: issue.Body,
-		WorktreePath: wtPath, LogPath: logPath, RepoSlug: repoSlug,
+		Branch: branch, WorktreePath: wtPath, LogPath: logPath, RepoSlug: repoSlug,
 		Timeout: d.Timeout,
 	})
 	if err != nil {
@@ -392,22 +394,6 @@ func (d Deps) logf(format string, a ...any) {
 	}
 	ts := time.Now().Format("15:04:05")
 	fmt.Fprintf(d.Stderr, "[%s] %s\n", ts, fmt.Sprintf(format, a...))
-}
-
-// LogPathFor returns the per-issue log path. Exposed for the cmd layer to
-// surface in user-facing messages.
-func LogPathFor(stateRoot, owner, repo, slug string, issueNumber int) string {
-	return worktree.LogPath(stateRoot, owner, repo, slug, issueNumber)
-}
-
-// WorktreePathFor returns the per-issue worktree path.
-func WorktreePathFor(stateRoot, owner, repo, slug string, issueNumber int) string {
-	return worktree.Path(stateRoot, owner, repo, slug, issueNumber)
-}
-
-// LockPathFor returns the per-project lock path.
-func LockPathFor(stateRoot, owner, repo, slug string) string {
-	return lock.Path(stateRoot, owner, repo, slug)
 }
 
 // DefaultStateRoot is ~/.klanky.

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/joshuapeters/klanky/internal/agent"
 	"github.com/joshuapeters/klanky/internal/config"
 	"github.com/joshuapeters/klanky/internal/gh"
+	"github.com/joshuapeters/klanky/internal/identifiers"
 	"github.com/joshuapeters/klanky/internal/snapshot"
 )
 
@@ -162,6 +163,7 @@ func TestRun_NothingToDo_AllClosed(t *testing.T) {
 	err := Run(context.Background(), Deps{
 		Runner: fake, Spawner: agentSpawnerAdapter{&fakeSpawner{}},
 		Config: cfg, ProjectSlug: "auth",
+		Identifiers: identifiers.New(stateRoot, "joshuapeters", "klanky", "auth"),
 		RepoRoot: dir, StateRoot: stateRoot, Output: "text",
 		Stdout: stdout, Stderr: stderr,
 	})
@@ -243,6 +245,7 @@ func TestRun_HappyPath_OneEligibleIssue(t *testing.T) {
 	err := Run(context.Background(), Deps{
 		Runner: fake, Spawner: agentSpawnerAdapter{&fakeSpawner{exitCode: 0}},
 		Config: cfg, ProjectSlug: "auth",
+		Identifiers: identifiers.New(stateRoot, "joshuapeters", "klanky", "auth"),
 		RepoRoot: dir, StateRoot: stateRoot, Output: "text",
 		Timeout: 5 * time.Second,
 		Stdout:  stdout, Stderr: stderr,
@@ -258,7 +261,7 @@ func TestRun_HappyPath_OneEligibleIssue(t *testing.T) {
 	}
 
 	// Lock cleanup.
-	if _, err := os.Stat(LockPathFor(stateRoot, "joshuapeters", "klanky", "auth")); !os.IsNotExist(err) {
+	if _, err := os.Stat(identifiers.New(stateRoot, "joshuapeters", "klanky", "auth").LockPath()); !os.IsNotExist(err) {
 		t.Errorf("lock should have been released")
 	}
 }

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -208,9 +208,3 @@ func fetchPRs(ctx context.Context, r gh.Runner, repoSlug, projectSlug string) (m
 	}
 	return idx, nil
 }
-
-// BranchForIssue returns the klanky branch name for a (project slug, issue
-// number) pair.
-func BranchForIssue(projectSlug string, issueNumber int) string {
-	return fmt.Sprintf("klanky/%s/issue-%d", projectSlug, issueNumber)
-}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -88,7 +88,7 @@ func TestFetch_FiltersUntrackedAndExtractsBlockers(t *testing.T) {
 			},
 		}},
 		PRsByBranch: map[string]PR{
-			BranchForIssue("auth", 42): {
+			"klanky/auth/issue-42": {
 				Number: 99, URL: "https://x", State: "OPEN",
 				HeadRefName: "klanky/auth/issue-42",
 			},
@@ -106,8 +106,3 @@ func TestFetch_UnknownSlug(t *testing.T) {
 	}
 }
 
-func TestBranchForIssue(t *testing.T) {
-	if got := BranchForIssue("auth", 42); got != "klanky/auth/issue-42" {
-		t.Errorf("BranchForIssue = %q", got)
-	}
-}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -8,22 +8,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/joshuapeters/klanky/internal/gh"
 )
-
-// Path returns the per-issue worktree path. owner and repo are lowercased.
-func Path(stateRoot, owner, repo, slug string, issueNumber int) string {
-	return filepath.Join(stateRoot, "worktrees", strings.ToLower(owner), strings.ToLower(repo), slug,
-		fmt.Sprintf("issue-%d", issueNumber))
-}
-
-// LogPath returns the per-issue agent log path.
-func LogPath(stateRoot, owner, repo, slug string, issueNumber int) string {
-	return filepath.Join(stateRoot, "logs", strings.ToLower(owner), strings.ToLower(repo), slug,
-		fmt.Sprintf("issue-%d.log", issueNumber))
-}
 
 // EnsureClean guarantees a fresh git worktree at wtPath on `branch`,
 // branched from `base`. Wipes any existing path and prunes git's worktree

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -8,22 +8,6 @@ import (
 	"github.com/joshuapeters/klanky/internal/gh"
 )
 
-func TestPath_Lowercases(t *testing.T) {
-	got := Path("/root", "JoshuaPeters", "Klanky", "auth", 42)
-	want := "/root/worktrees/joshuapeters/klanky/auth/issue-42"
-	if got != want {
-		t.Errorf("Path = %q, want %q", got, want)
-	}
-}
-
-func TestLogPath(t *testing.T) {
-	got := LogPath("/root", "owner", "repo", "auth", 42)
-	want := "/root/logs/owner/repo/auth/issue-42.log"
-	if got != want {
-		t.Errorf("LogPath = %q, want %q", got, want)
-	}
-}
-
 func TestEnsureClean_RunsExpectedCommands(t *testing.T) {
 	dir := t.TempDir()
 	wt := dir + "/wt/issue-1"


### PR DESCRIPTION
## Summary

- Introduces `internal/identifiers.Identifiers` — a struct constructed once per run from `(stateRoot, owner, repo, slug)` that vends all derived string identifiers (branch name, worktree path, log path, lock path, branch prefix) via methods
- Removes `worktree.Path`, `worktree.LogPath`, `lock.Path`, `snapshot.BranchForIssue`, and the three `runner.LogPathFor/WorktreePathFor/LockPathFor` re-export wrappers
- Consolidates two hardcoded `klanky/%s/issue-%d` format strings in `envelope.go` behind `EnvelopeData.Branch`

## Test Plan
- [ ] `go test ./...` passes (18 packages)
- [ ] `internal/identifiers` has its own test covering all five methods and owner/repo lowercasing
- [ ] Tests that previously covered `worktree.Path`, `worktree.LogPath`, and `lock.Path` in their own packages are removed (now covered by `identifiers_test.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)